### PR TITLE
not only aws storage

### DIFF
--- a/templates/storage.yaml
+++ b/templates/storage.yaml
@@ -13,6 +13,8 @@ spec:
   clusterIP: None
   selector:
     app: zipkin-cassandra
+
+{{if eq .Values.cassandra.storageProvider "aws"}}
 ---
 kind: StorageClass
 apiVersion: storage.k8s.io/v1
@@ -26,7 +28,7 @@ metadata:
 provisioner: kubernetes.io/aws-ebs
 parameters:
   type: gp2
-
+{{ end }}
 ---
 apiVersion: apps/v1beta1
 kind: StatefulSet
@@ -44,12 +46,19 @@ spec:
   - metadata:
       name: data-storage
     spec:
-      storageClassName: {{ .Release.Name }}-zipkin-cassandra-storage
+{{- if .Values.cassandra.volumeClaimTemplates }}
+{{- if .Values.cassandra.volumeClaimTemplates.spec }}
+{{ toYaml .Values.cassandra.volumeClaimTemplates.spec | indent 6}}
+{{- else }}
+{{- end }}
+{{- else}}
+      storageClassName: "{{ .Release.Name }}-zipkin-cassandra-storage"
       accessModes:
        - ReadWriteOnce
       resources:
         requests:
-          storage: {{ .Values.cassandra.pvSize }}
+          storage: "{{ .Values.cassandra.pvSize }}"
+{{- end }}
   template:
     metadata:
       labels:

--- a/values.yaml
+++ b/values.yaml
@@ -47,9 +47,9 @@ configmap:
     key: cassandra.localdc
 
 ingress:
-  class: "istio"
+  class: "nginx"
   host: placeholder
-  path: /.*
+  path: /
   serviceName: zipkin-ui
   servicePort: 9411
 
@@ -66,6 +66,7 @@ cassandra:
   tag: 2
   replicas: 1
   pvSize: 20Gi
+  storageProvider: "aws"
   resources:
     ramMb: 3500
     cpuRequest: 200m


### PR DESCRIPTION
Adding the following fields to your `values.yaml` should now break the cassandra dependance on aws ebs:

```
cassandra:
  storageProvider: "none"
  volumeClaimTemplates:
    spec:
      storageClassName: "YOUR_CLASS_NAME"
      accessModes:
       - ReadWriteOnce
      resources:
        requests:
          storage: "20Gi"
```